### PR TITLE
Update sample code to srand and rand

### DIFF
--- a/source/samples/ufortune/ufortune.c
+++ b/source/samples/ufortune/ufortune.c
@@ -186,8 +186,9 @@ int main(int argc, char **argv)
         fprintf(stderr, "%s: no fortunes found.\n", programName);
         exit(-1);
     }
-
-    i = (unsigned long long)time(NULL) % numFortunes;    /*  Use time to pick a somewhat-random fortune.  */
+    
+    srand(time(NULL));
+    i = rand() % numFortunes;    /*  Use time to pick a somewhat-random fortune.  */
     resString = ures_getStringByIndex(fortunes_r, i, &len, &err);
     if (U_FAILURE(err)) {
         fprintf(stderr, "%s: ures_getStringByIndex(%d) failed, %s\n", programName, i, u_errorName(err));

--- a/source/samples/ufortune/ufortune.c
+++ b/source/samples/ufortune/ufortune.c
@@ -187,7 +187,7 @@ int main(int argc, char **argv)
         exit(-1);
     }
 
-    i = (int)time(NULL) % numFortunes;    /*  Use time to pick a somewhat-random fortune.  */
+    i = (unsigned long long)time(NULL) % numFortunes;    /*  Use time to pick a somewhat-random fortune.  */
     resString = ures_getStringByIndex(fortunes_r, i, &len, &err);
     if (U_FAILURE(err)) {
         fprintf(stderr, "%s: ures_getStringByIndex(%d) failed, %s\n", programName, i, u_errorName(err));


### PR DESCRIPTION
the previous implementation might have made variable `i` to negative number, since time() returns a 64 bit value, and was explicitly casted to `int`. To avoid this problem (and the recommended way), use srand() and rand() to generate randomized index.